### PR TITLE
Fix event duration logic and photo script bug

### DIFF
--- a/cronograma_app.html
+++ b/cronograma_app.html
@@ -315,8 +315,10 @@
             const endTime = new Date(now);
             endTime.setHours(parseInt(endParts[0], 10), parseInt(endParts[1], 10), 0, 0);
 
+            const eventDurationLimit = new Date(startTime.getTime() + 30 * 60000); // 30 minutes after start
+
             const minutesToStart = Math.ceil((startTime - now) / 60000);
-            const isHappening = now >= startTime && now <= endTime;
+            const isHappening = now >= startTime && now <= Math.min(endTime, eventDurationLimit);
             const isUpcoming = minutesToStart > 0 && minutesToStart <= 15;
 
             return { isHappening, isUpcoming, minutesToStart };
@@ -354,7 +356,10 @@
             // FOR TESTING: You can set a mock time here
             // now.setHours(11, 20, 0);
 
-            let activeViews = ['view-schedule', 'view-photo']; // Default views
+            let activeViews = ['view-schedule']; // Default views
+            if (photos.length > 0) {
+                activeViews.push('view-photo');
+            }
 
             // Find relevant events
             let activeEvents = scheduleEvents.map(event => {

--- a/update_photos.py
+++ b/update_photos.py
@@ -1,5 +1,6 @@
 import os
 import re
+import json
 
 def update_photos():
     photos_dir = 'arraia_fotos'
@@ -17,7 +18,7 @@ def update_photos():
     photos.sort()
 
     # Format the array as a JavaScript array string
-    photos_js_array = "['" + "', '".join(photos) + "']" if photos else "[]"
+    photos_js_array = json.dumps(photos) if photos else "[]"
 
     # Read the HTML file
     with open(html_file, 'r', encoding='utf-8') as f:


### PR DESCRIPTION
This submission addresses two issues in the signage screens:
1. The "event happening now" screen is now hard-capped to disappear 30 minutes after the event starts, so they don't linger if events finish early.
2. The photo bug is fixed: it no longer tries to show a broken image if there are no photos in the `arraia_fotos` folder, and the python update script now handles image names with apostrophes/quotes correctly by utilizing `json.dumps`.

---
*PR created automatically by Jules for task [8276581314180511021](https://jules.google.com/task/8276581314180511021) started by @RodrigoValecred*