### PR TITLE
Fix layout overflow in cronograma app

### DIFF
--- a/cronograma_app.html
+++ b/cronograma_app.html
@@ -36,7 +36,7 @@
             display: flex;
             flex-direction: column;
             align-items: center;
-            padding-top: 50px;
+            padding-top: 35px;
             padding-bottom: 20px;
             overflow-y: hidden;
         }
@@ -76,7 +76,7 @@
         h1 {
             font-family: 'Montserrat', sans-serif;
             color: #4b3223;
-            font-size: 3rem; /* Much smaller header */
+            font-size: 2.2rem; /* Much smaller header */
             line-height: 1.1;
             text-align: center;
             font-weight: 800;
@@ -87,15 +87,15 @@
         .subtitle {
             font-family: 'Nunito', sans-serif;
             color: #4b3223;
-            font-size: 1.2rem; /* Smaller subtitle */
-            margin-bottom: 15px; /* Reduced margin */
+            font-size: 1rem; /* Smaller subtitle */
+            margin-bottom: 8px; /* Reduced margin */
             font-weight: 600;
         }
 
         .schedule-list {
             display: flex;
             flex-direction: column;
-            gap: 10px; /* Much smaller gap between items */
+            gap: 6px; /* Much smaller gap between items */
             width: 80%;
             max-width: 800px;
         }
@@ -103,15 +103,15 @@
         .schedule-item {
             display: flex;
             align-items: center;
-            gap: 15px; /* Reduced gap between time and text */
+            gap: 12px; /* Reduced gap between time and text */
         }
 
         .time-badge {
             background-color: #facd49;
             color: #4b3223;
             font-weight: 700;
-            font-size: 1.1rem; /* Smaller time text */
-            padding: 5px 10px; /* Reduced padding */
+            font-size: 1rem; /* Smaller time text */
+            padding: 3px 8px; /* Reduced padding */
             border-radius: 4px;
             position: relative;
             min-width: 140px; /* Reduced width */
@@ -143,7 +143,7 @@
 
         .event-name {
             color: #4b3223;
-            font-size: 1.2rem; /* Smaller event text */
+            font-size: 1.1rem; /* Smaller event text */
             font-weight: 600;
         }
 


### PR DESCRIPTION
- Decreased `padding-top` of the inner container.
- Decreased font sizes for `h1`, `.subtitle`, `.time-badge`, and `.event-name`.
- Decreased vertical gaps in the schedule list and between schedule items.
- Decreased padding in `.time-badge`.
- Ensured testing artifacts were removed before committing.

---
*PR created automatically by Jules for task [10882496515650884805](https://jules.google.com/task/10882496515650884805) started by @RodrigoValecred*