### PR TITLE
Add video playback support to schedule app

### DIFF
--- a/cronograma_app.html
+++ b/cronograma_app.html
@@ -265,7 +265,8 @@
 
         <!-- VIEW: PHOTO -->
         <div id="view-photo" class="view" style="display: none; flex-direction: column; align-items: center; justify-content: center; width: 100%; height: 90%; position: relative; overflow: hidden;">
-            <img id="photo-display" src="" style="max-height: 80vh; max-width: 90vw; border: 8px solid white; box-shadow: 0 4px 8px rgba(0,0,0,0.3); transform: rotate(-2deg); border-radius: 4px;" alt="Arraiá Photo">
+            <img id="photo-display" src="" style="max-height: 80vh; max-width: 90vw; border: 8px solid white; box-shadow: 0 4px 8px rgba(0,0,0,0.3); transform: rotate(-2deg); border-radius: 4px; display: block;" alt="Arraiá Photo">
+            <video id="video-display" src="" style="max-height: 80vh; max-width: 90vw; border: 8px solid white; box-shadow: 0 4px 8px rgba(0,0,0,0.3); transform: rotate(-2deg); border-radius: 4px; display: none;" autoplay muted loop playsinline></video>
             <img id="milhao-mascot" class="milhao-mascot" src="time_de_milhoes.png" alt="Time de milhões">
         </div>
 
@@ -370,7 +371,20 @@
         function updatePhotoContent() {
             if (photos.length > 0) {
                 const randomPhoto = photos[Math.floor(Math.random() * photos.length)];
-                document.getElementById('photo-display').src = randomPhoto + '?t=' + new Date().getTime(); // cache bust
+                const isVideo = randomPhoto.toLowerCase().match(/\.(mp4|webm|ogg|mov|avi)$/);
+
+                const photoEl = document.getElementById('photo-display');
+                const videoEl = document.getElementById('video-display');
+
+                if (isVideo) {
+                    photoEl.style.display = 'none';
+                    videoEl.style.display = 'block';
+                    videoEl.src = randomPhoto;
+                } else {
+                    videoEl.style.display = 'none';
+                    photoEl.style.display = 'block';
+                    photoEl.src = randomPhoto + '?t=' + new Date().getTime(); // cache bust
+                }
             }
         }
 

--- a/update_photos.py
+++ b/update_photos.py
@@ -6,8 +6,8 @@ def update_photos():
     photos_dir = 'arraia_fotos'
     html_file = 'cronograma_app.html'
 
-    # Get list of valid images
-    valid_extensions = ('.jpg', '.jpeg', '.png', '.webp', '.gif')
+    # Get list of valid images and videos
+    valid_extensions = ('.jpg', '.jpeg', '.png', '.webp', '.gif', '.mp4', '.webm', '.ogg', '.mov', '.avi')
     try:
         files = os.listdir(photos_dir)
         photos = [f"{photos_dir}/{f}" for f in files if f.lower().endswith(valid_extensions)]


### PR DESCRIPTION
This submission enables the display of video files within the schedule application's photo view rotation. Video extensions are now parsed by the update script, and the frontend dynamically handles displaying videos (muted, looping, autoplaying) interchangeably with photos based on the file extension.

---
*PR created automatically by Jules for task [16997336219193220960](https://jules.google.com/task/16997336219193220960) started by @RodrigoValecred*